### PR TITLE
Fix bug with no value in field. In DB this fields integer so must be …

### DIFF
--- a/models/Event.php
+++ b/models/Event.php
@@ -55,9 +55,9 @@ class Event extends Model
     ];
 
     public $attributes = [
-        'day' => '',
-        'month' => '',
-        'year' => '',
+        'day' => 0,
+        'month' => 0,
+        'year' => 0,
         'human_time' => '',
         'carbon_time' => '',
         'owner_name' => '',

--- a/updates/add_event_fields.php
+++ b/updates/add_event_fields.php
@@ -1,0 +1,30 @@
+<?php namespace KurtJensen\MyCalendar\Updates;
+
+use DB;
+use October\Rain\Database\Updates\Migration;
+use Schema;
+
+class AddEventFields extends Migration {
+    
+    public function up() {
+        Schema::table('kurtjensen_mycal_events', function ($table) {
+            $table->text('excerpt')->nullable();
+            $table->date('multidate')->nullable();
+            $table->date('excluded')->nullable();
+            $table->integer('allday')->nullable()->unsigned();
+            $table->date('thru')->nullable();
+            $table->text('recur')->nullable();
+        });
+    }
+
+    public function down() {
+        Schema::table('kurtjensen_mycal_events', function ($table) {
+            $table->dropColumn('excerpt');
+            $table->dropColumn('multidate');
+            $table->dropColumn('excluded');
+            $table->dropColumn('allday');
+            $table->dropColumn('thru');
+            $table->dropColumn('recur');
+        });
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -47,3 +47,6 @@
 1.1.5: !!! This is an important update that contains breaking changes. MyCalendar will now be using Passage Permission Keys for permissions and you will need to install the plugin using code "kurtjensen.passage" if you use permissions for your events. If you do not install Passage Permission Keys plugin then your protected events may not show or may be visible to anyone who visits your site until you do add PassagePermission Keys plugin. This update also added raw data element to event array and applied config date/time to all components.
 1.1.6: Added messageURL() to enable Author Notices
 1.1.7: Added Backend Settings Permissions
+1.1.8:
+    - Added fields excerpt, multidate, excluded, allday, thru, recur
+    - add_event_fields.php


### PR DESCRIPTION
…same walue provided?

"SQLSTATE[HY000]: General error: 1366 Incorrect integer value: '' for column 'day' at row 1 (SQL: insert into `kurtjensen_mycal_events` (`day`, `month`, `year`, `name`, `is_published`, `date`, `time`, `text`, `link`, `updated_at`, `created_at`) values (, , , Sas, 1, 2016-02-29 00:00:00, , , , 2016-02-28 13:41:21, 2016-02-28 13:41:21))" on line 651 of C:\Users\apolt\Desktop\octobercms\sites\sitesforchurch\vendor\laravel\framework\src\Illuminate\Database\Connection.php