### PR TITLE
Dialog partial qualified with @

### DIFF
--- a/components/Events.php
+++ b/components/Events.php
@@ -136,7 +136,7 @@ class Events extends ComponentBase {
 					'#EventDetail"
             	data-request="onShowEvent"
             	data-request-data="evid:' . $occ->id . ($relation_name == 'event' ? '' : ',rel:\'' . $relation_name . '\'') . '"
-            	data-request-update="\'' . $this->compLink . '::details\':\'#EventDetail\'" data-toggle="modal" data-target="#myModal');
+            	data-request-update="\'' . '@details\':\'#EventDetail\'" data-toggle="modal" data-target="#myModal');
 				$time = $occ->is_allday ? '(' . Lang::get('kurtjensen.mycalendar::lang.occurrence.is_allday') . ')'
 				: $occ->start_at->format($timeFormat);
 


### PR DESCRIPTION
Hi,
Just found a bug: I used the MonthEvent, changed the alias froim the default, and when clicking on an event in the displayed calendar, got an error "MonthEvent component not found. This was because the partial name in the data-request-update attribute was prefixed by the component name. I aliased it to another name, en as a result the component name in the partial was unavailable.
I changed this prefix simply to "@", using the default October search algorithm for partials, and this fixed the error.