### PR TITLE
Exception fixed when daysfuture = 0 and dayspast = 0 and no month/yea…

### DIFF
--- a/components/Events.php
+++ b/components/Events.php
@@ -82,7 +82,8 @@ class Events extends ComponentBase {
 			$month_end = $month_start->copy()->addDays($this->daysfuture);
 			$month_start->subDays($this->dayspast);
 		} else {
-			$month_start = new Carbon($this->year . '/' . $this->month . '/1 00:00:00');
+		    $now = Carbon::now();
+			$month_start = new Carbon(($this->year ?: $now->year) . '/' . ($this->month ?: $now->month) . '/1 00:00:00');
 			$month_end = $month_start->copy()->addMonth(1);
 		}
 


### PR DESCRIPTION
Hi,
Just found another bug: I used the MonthEvent, and wanted to use the feature to use the current month when both past days and future days in the component properties-box are set to 0.
This triggers an exception when the month and year URL components are absent. 
I used the current year and month in the case of absent URL parameters, which fixed the exception. In this case, the calender now shows all events in the current month.